### PR TITLE
Add container image build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Git
+.git
+.gitignore
+
+# CI/CD
+.github
+
+# Build artifacts
+dist/
+*.exe
+*.dll
+*.so
+*.dylib
+
+# Test files
+*.test
+*.out
+
+# Editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Documentation
+*.md
+!README.md
+
+# Other
+.env
+.env.*

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,60 @@
+name: Build and Push Docker Image
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract metadata
+        id: meta
+        run: |
+          # Extract tag name
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+
+          # Extract commit SHA (short)
+          COMMIT=$(git rev-parse --short HEAD)
+          echo "commit=${COMMIT}" >> $GITHUB_OUTPUT
+
+          # Build date
+          BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "build_date=${BUILD_DATE}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.tag }}
+            ghcr.io/${{ github.repository }}:latest
+          build-args: |
+            VERSION=${{ steps.meta.outputs.tag }}
+            COMMIT=${{ steps.meta.outputs.commit }}
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,49 @@
+# Build stage
+FROM golang:1.23-alpine AS builder
+
+WORKDIR /build
+
+# Install build dependencies
+RUN apk add --no-cache git ca-certificates
+
+# Copy go mod files
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
+COPY . .
+
+# Build the application
+ARG VERSION=dev
+ARG COMMIT=none
+ARG BUILD_DATE=unknown
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${BUILD_DATE}" \
+    -o dewy-testapp .
+
+# Runtime stage
+FROM alpine:latest
+
+# Install CA certificates for HTTPS requests
+RUN apk --no-cache add ca-certificates
+
+# Create non-root user
+RUN addgroup -g 1000 appuser && \
+    adduser -D -u 1000 -G appuser appuser
+
+WORKDIR /app
+
+# Copy binary from builder
+COPY --from=builder /build/dewy-testapp .
+
+# Change ownership to non-root user
+RUN chown -R appuser:appuser /app
+
+# Switch to non-root user
+USER appuser
+
+# Expose default port
+EXPOSE 3333
+
+# Run the application
+CMD ["/app/dewy-testapp"]


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically build and push container images on tag creation
- Add Dockerfile with multi-stage build for optimized image size
- Add .dockerignore to exclude unnecessary files from the image

## Changes
### Container Build Workflow (.github/workflows/container.yml)
- Triggers on tag push (same as GoReleaser workflow)
- Builds multi-platform images (linux/amd64, linux/arm64)
  - Compatible with Intel Macs, Apple Silicon Macs, and Linux systems
- Pushes to GitHub Container Registry (ghcr.io)
- Tags images with both tag name and latest
- Uses build cache for faster builds
- Injects version, commit, and build date into the binary

### Dockerfile
- Multi-stage build for minimal image size
- Based on golang:1.23-alpine for building
- Runtime image based on alpine:latest
- Runs as non-root user for security
- Exposes port 3333 (default application port)

### .dockerignore
- Excludes git, CI/CD, build artifacts, and other unnecessary files

## Container Usage
Once merged and a tag is created, the image can be pulled and run with Docker or Podman:

```bash
# Pull image
docker pull ghcr.io/linyows/dewy-testapp:latest
# or
podman pull ghcr.io/linyows/dewy-testapp:latest

# Run container
docker run -d -p 3333:3333 ghcr.io/linyows/dewy-testapp:latest
# or
podman run -d -p 3333:3333 ghcr.io/linyows/dewy-testapp:latest
```

## Test plan
- [x] Create Dockerfile with multi-stage build
- [x] Create .dockerignore file
- [x] Create GitHub Actions workflow for container builds
- [ ] Merge this PR
- [ ] Create a new tag to trigger the workflow
- [ ] Verify the container image is built and pushed to ghcr.io
- [ ] Test pulling and running the image with Docker/Podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)